### PR TITLE
Update infer_tool.py

### DIFF
--- a/inference/infer_tool.py
+++ b/inference/infer_tool.py
@@ -167,7 +167,9 @@ class Svc(object):
               cluster_infer_ratio=0,
               auto_predict_f0=False,
               noice_scale=0.4):
-        speaker_id = self.spk2id[speaker]
+        if not speaker_id and type(speaker) is int:
+            if len(self.spk2id.__dict__) >= speaker:
+                speaker_id = speaker
         sid = torch.LongTensor([int(speaker_id)]).to(self.dev).unsqueeze(0)
         c, f0, uv = self.get_unit_f0(raw_path, tran, cluster_infer_ratio, speaker)
         if "half" in self.net_g_path and torch.cuda.is_available():


### PR DESCRIPTION
4.0的flask_api.py推理函数直接传递了speaker_id，因此需要在此处判断speaker变量是speaker还是speaker_id