### PR TITLE
Update train.py 更改numba的logging优先级

### DIFF
--- a/train.py
+++ b/train.py
@@ -3,6 +3,8 @@ import multiprocessing
 import time
 
 logging.getLogger('matplotlib').setLevel(logging.WARNING)
+logging.getLogger('numba').setLevel(logging.WARNING)
+
 import os
 import json
 import argparse


### PR DESCRIPTION
原train.py在colab上测试会出现大量numba DEBUG日志
修改优先级解决了该问题