### PR TITLE
Lock numpy and scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask
 Flask_Cors
 gradio
-numpy
+numpy==1.23.0
 pyworld==0.2.5
-scipy==1.7.3
+scipy==1.10.0
 SoundFile==0.12.1
 torch==1.13.1
 torchaudio==0.13.1


### PR DESCRIPTION
Please update and lock numpy and scipy version.

My local system is Ubuntu 22.04, and after running multiple tests, I found that locking the versions of numpy and scipy is the best choice.

Reason:
1.The latest version of numpy does not conform to the old version of the C API.
2.Updating the version of scipy is to break free from the numpy version restrictions imposed by scipy.

Why:
If not, .This means that the API version of the latest version of numpy does not match the required version.This seems to be a conflict caused by pyworld or scipy with the newer version of numpy.

And I got it wrong with run "python preprocess_hubert_f0.py" at first time.

After updating and locking the versions, everything is working smoothly now.
