### PR TITLE
fix: cast `f0_coarse` to int

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -205,7 +205,7 @@ def f0_to_coarse(f0):
 
   f0_mel[f0_mel <= 1] = 1
   f0_mel[f0_mel > f0_bin - 1] = f0_bin - 1
-  f0_coarse = (f0_mel + 0.5).long() if is_torch else np.rint(f0_mel).astype(np.int)
+  f0_coarse = (f0_mel + 0.5).int() if is_torch else np.rint(f0_mel).astype(np.int)
   assert f0_coarse.max() <= 255 and f0_coarse.min() >= 1, (f0_coarse.max(), f0_coarse.min())
   return f0_coarse
 


### PR DESCRIPTION
It is unnecessary to convert to a `long` type in PyTorch, as long types are 64-bit integers in PyTorch.
We expect the value to be within the range of 1 to 255,  `long` is far beyond the scope of what we expect.
`int` types in PyTorch are 32-bit integers, which are sufficient for our needs.

Background:
I found this issue while testing `mps`.
The max and min methods of long types is not implement in mps .