### PR TITLE
Fix error: math domain error when loss is too low

### DIFF
--- a/train.py
+++ b/train.py
@@ -225,8 +225,7 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
                 losses = [loss_disc, loss_gen, loss_fm, loss_mel, loss_kl]
                 reference_loss=0
                 for i in losses:
-                    reference_loss += math.log(i, 10)
-                reference_loss*=10
+                    reference_loss += i
                 logger.info('Train Epoch: {} [{:.0f}%]'.format(
                     epoch,
                     100. * batch_idx / len(train_loader)))


### PR DESCRIPTION
May be helpful for the following bugs:

Traceback (most recent call last):
  File "train.py", line 331, in <module>
    main()
  File "train.py", line 53, in main
    mp.spawn(run, nprocs=n_gpus, args=(n_gpus, hps,))
  File "/home/ubuntu/so-vits-svc/venv/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 240, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method='spawn')
  File "/home/ubuntu/so-vits-svc/venv/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 198, in start_processes
    while not context.join():
  File "/home/ubuntu/so-vits-svc/venv/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 160, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException:

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/home/ubuntu/so-vits-svc/venv/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/home/ubuntu/svc4.0/so-vits-svc/train.py", line 138, in run
    train_and_evaluate(rank, epoch, hps, [net_g, net_d], [optim_g, optim_d], [scheduler_g, scheduler_d], scaler,
  File "/home/ubuntu/svc4.0/so-vits-svc/train.py", line 228, in train_and_evaluate
    reference_loss += math.log(i, 10)
ValueError: math domain error
