### PR TITLE
fix(colab): Add missing dependencies

### DIFF
--- a/sovits4_for_colab.ipynb
+++ b/sovits4_for_colab.ipynb
@@ -80,7 +80,7 @@
     "!git clone https://github.com/svc-develop-team/so-vits-svc -b 4.1-Stable\n",
     "%pip uninstall -y torchdata torchtext\n",
     "%pip install --upgrade pip setuptools numpy numba\n",
-    "%pip install pyworld praat-parselmouth fairseq tensorboardX torchcrepe librosa==0.9.1 pyyaml pynvml pyloudnorm\n",
+    "%pip install pyworld praat-parselmouth fairseq tensorboardX torchcrepe librosa==0.9.1 pyyaml pynvml pyloudnorm faiss-gpu\n",
     "%pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118\n",
     "exit()"
    ]


### PR DESCRIPTION
missing faiss
```
Traceback (most recent call last):
  File "/content/so-vits-svc/inference_main.py", line 10, in <module>
    from inference import infer_tool
  File "/content/so-vits-svc/inference/infer_tool.py", line 19, in <module>
    import utils
  File "/content/so-vits-svc/utils.py", line 18, in <module>
    import faiss
ModuleNotFoundError: No module named 'faiss'
```

> https://github.com/facebookresearch/faiss/issues/890#issuecomment-1508446182
> Note that for faiss-gpu, this will install version 1.7.2, not the latest

