### PR TITLE
Corrected inaccurate package names

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,4 @@ transformers
 edge_tts
 pyyaml
 pynvml
-ffmpeg
 faiss-cpu

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -26,5 +26,4 @@ transformers
 edge_tts
 pyyaml
 pynvml
-ffmpeg
-faiss
+faiss-cpu


### PR DESCRIPTION
`ffmpeg` -> `ffmpeg-python`
`faiss` -> `faiss-cpu`