### PR TITLE
Simplifying expressions in resample.py

### DIFF
--- a/resample.py
+++ b/resample.py
@@ -45,7 +45,7 @@ def process(item):
         resampled_wav = resample_wav(wav, sr, args.sr2)
 
         if not args.skip_loudnorm:
-            resampled_wav /= max(resampled_wav.max(), -resampled_wav.min())
+            resampled_wav /= np.max(np.abs(resampled_wav))
 
         save_path2 = os.path.join(args.out_dir2, speaker, wav_name)
         save_wav_to_path(resampled_wav, save_path2, args.sr2)


### PR DESCRIPTION
### Overview
Simplified resampled_wav expression

### About the change
```python
resampled_wav /= max(resampled_wav.max(), -resampled_wav.min())
```
I think the right side of this equation calculates the maximum absolute value of the resampled_wav and normalizes it to the range of -1 to 1 for the waveform data using the `/=` operator.
So I wrote it more concisely using `np.abs` and max for absolute values.

```python
resampled_wav /= np.max(np.abs(resampled_wav))
```

I am not fluent in English, so please feel free to ask me if anything is unclear.