### PR TITLE
对浅扩散模型在 whisper-ppg-large 作为编码器情况下的训练做了补充说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ python train_diff.py -c configs/diffusion.yaml
 
 During training, the model files will be saved to `logs/44k`, and the diffusion model will be saved to `logs/44k/diffusion`
 
+When using `whisper-ppg-large` as the speech_encoder, it's not possible to use the pre-trained models from [Diffusion-SVC](https://github.com/CNChTu/Diffusion-SVC). You need to delete all the files in the `logs/44k/diffusion` directory before starting the training. This change makes the training mode start from scratch, rather than starting from the pre-trained model.
+
 ## 🤖 Inference
 
 Use [inference_main.py](https://github.com/svc-develop-team/so-vits-svc/blob/4.0/inference_main.py)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -346,6 +346,8 @@ python train_diff.py -c configs/diffusion.yaml
 
 模型训练结束后，模型文件保存在`logs/44k`目录下，扩散模型在`logs/44k/diffusion`下
 
+在使用 `whisper-ppg-large` 作为 speech_encoder 的场合，无法使用 [Diffusion-SVC](https://github.com/CNChTu/Diffusion-SVC) 中的预训练模型，需要将 `logs/44k/diffusion` 目录清空再进行训练，使得训练的模式变为从头开始训练，而不是从预训练模型开始。 
+
 ## 🤖 推理
 
 使用 [inference_main.py](inference_main.py)


### PR DESCRIPTION
在直接使用从 Diffusion-SVC 下载的预训练模型进行训练的场合，会出现以下错误：
```
 [*] restoring model from logs/44k/diffusion\model_0.pt
Traceback (most recent call last):
  File "train_diff.py", line 55, in <module>
    initial_global_step, model, optimizer = utils.load_model(args.env.expdir, model, optimizer, device=args.device)
  File "H:\so-vits-svc\diffusion\logger\utils.py", line 124, in load_model
    model.load_state_dict(ckpt['model'], strict=False)
  File "H:\so-vits-svc\venv\lib\site-packages\torch\nn\modules\module.py", line 1671, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for Unit2Mel:
        size mismatch for unit_embed.weight: copying a param with shape torch.Size([256, 1024]) from checkpoint, the shape in current model is torch.Size([256, 1280]).

```